### PR TITLE
Use timezone directly from /usr/share/zoneinfo rather than /usr/share/zoneinfo/posix

### DIFF
--- a/datetime.cpp
+++ b/datetime.cpp
@@ -83,7 +83,7 @@ void MXDateTime::startup()
 
     // Time zone areas.
     QByteArray zoneOut;
-    execute("find -L /usr/share/zoneinfo/posix -mindepth 2 -type f -printf %P\\n", &zoneOut);
+    execute("find -L /usr/share/zoneinfo -mindepth 2 ! -path '*/posix/*' ! -path '*/right/*' -type f -printf %P\\n", &zoneOut);
     zones = zoneOut.trimmed().split('\n');
     cmbTimeZone->blockSignals(true); // Keep blocked until loadSysTimeConfig().
     cmbTimeArea->clear();


### PR DESCRIPTION
Should work but not tested yet via the application yet. Checking from command line, both previous and updated commands give same output.

See https://github.com/MX-Linux/mx-timeset/pull/1 for more details.

Please test once before merging.